### PR TITLE
[codex] Center HyperFrames demo preview

### DIFF
--- a/demo/README.md
+++ b/demo/README.md
@@ -1,6 +1,6 @@
 # claude-engram — demo animations
 
-Five HyperFrames-ready compositions (1920×1080, 30fps, GSAP) that showcase the core engram features. Each is a standalone `.html` file with a `data-composition-id` for the HyperFrames renderer and a built-in fallback preview mode.
+Five HyperFrames-ready compositions (1920×800, 30fps, GSAP) that showcase the core engram features. Each is a standalone `.html` file with a `data-composition-id` for the HyperFrames renderer and a built-in fallback preview mode.
 
 ## Preview locally
 
@@ -10,8 +10,8 @@ Any of the files works directly in a browser — no build step, no server needed
 open demo/session-flow.html        # or any other .html
 ```
 
-Preview behavior (when viewport ≠ 1920×1080):
-- Auto-scales the 1920×1080 stage to fit the window.
+Preview behavior (when viewport ≠ 1920×800):
+- Auto-scales and centers the 1920×800 stage to fit the window.
 - Auto-replays the timeline on page load.
 - **Click anywhere** to replay.
 - **Resize** the window to re-fit.

--- a/demo/engram-hero.html
+++ b/demo/engram-hero.html
@@ -832,10 +832,15 @@
     /* preview helpers */
     function fitStage() {
       const stage = document.getElementById('stage');
-      const scale = Math.min(window.innerWidth / 1920, window.innerHeight / 1080);
+      const stageWidth = 1920;
+      const stageHeight = 800;
+      const scale = Math.min(window.innerWidth / stageWidth, window.innerHeight / stageHeight);
+      stage.style.position = 'absolute';
+      stage.style.left = `${(window.innerWidth - stageWidth * scale) / 2}px`;
+      stage.style.top = `${(window.innerHeight - stageHeight * scale) / 2}px`;
       stage.style.transform = `scale(${scale})`;
     }
-    const isPreview = window.innerWidth !== 1920 || window.innerHeight !== 1080;
+    const isPreview = window.innerWidth !== 1920 || window.innerHeight !== 800;
     if (isPreview) {
       document.body.classList.add('preview');
       fitStage();

--- a/demo/scale-beat.html
+++ b/demo/scale-beat.html
@@ -465,10 +465,15 @@
     /* ───── Preview helpers (not used by HyperFrames render) ───── */
     function fitStage() {
       const stage = document.getElementById('stage');
-      const scale = Math.min(window.innerWidth / 1920, window.innerHeight / 1080);
+      const stageWidth = 1920;
+      const stageHeight = 800;
+      const scale = Math.min(window.innerWidth / stageWidth, window.innerHeight / stageHeight);
+      stage.style.position = 'absolute';
+      stage.style.left = `${(window.innerWidth - stageWidth * scale) / 2}px`;
+      stage.style.top = `${(window.innerHeight - stageHeight * scale) / 2}px`;
       stage.style.transform = `scale(${scale})`;
     }
-    const isPreview = window.innerWidth !== 1920 || window.innerHeight !== 1080;
+    const isPreview = window.innerWidth !== 1920 || window.innerHeight !== 800;
     if (isPreview) {
       document.body.classList.add('preview');
       fitStage();

--- a/demo/session-flow.html
+++ b/demo/session-flow.html
@@ -30,6 +30,10 @@
       box-sizing: border-box;
     }
     .win {
+      width: 100%;
+      max-width: 1660px;
+      margin: 0 auto;
+      box-sizing: border-box;
       display: flex; flex-direction: column; height: 100%;
       font-size: 22px; line-height: 1.5;
     }
@@ -365,10 +369,15 @@
     // Preview helpers (not used by HyperFrames render)
     function fitStage() {
       const stage = document.getElementById('stage');
-      const scale = Math.min(window.innerWidth / 1920, window.innerHeight / 1080);
+      const stageWidth = 1920;
+      const stageHeight = 800;
+      const scale = Math.min(window.innerWidth / stageWidth, window.innerHeight / stageHeight);
+      stage.style.position = 'absolute';
+      stage.style.left = `${(window.innerWidth - stageWidth * scale) / 2}px`;
+      stage.style.top = `${(window.innerHeight - stageHeight * scale) / 2}px`;
       stage.style.transform = `scale(${scale})`;
     }
-    const isPreview = window.innerWidth !== 1920 || window.innerHeight !== 1080;
+    const isPreview = window.innerWidth !== 1920 || window.innerHeight !== 800;
     if (isPreview) {
       document.body.classList.add('preview');
       fitStage();


### PR DESCRIPTION
## Summary

- Center the HyperFrames demo preview stage using the real 1920x800 composition size.
- Limit and center the session-flow terminal content so empty space is balanced instead of sitting on the right.
- Update the demo README to document the 1920x800 preview target.

## Validation

- Ran git diff --check.
- Captured demo/session-flow.html with headless Chrome before and after the layout change.