### PR TITLE
feat: pre-launch readiness — CONTRIBUTING + PR template + README badges

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,16 @@
+## Summary
+
+<!-- 1-3 bullets. What changed and why (focus on why; the diff shows what). -->
+
+-
+
+## Test plan
+
+<!-- Markdown checklist of what you ran locally. -->
+
+- [ ] `uv run ruff check .`
+- [ ] `uv run ruff format --check .`
+- [ ] `uv run pytest -q`
+- [ ] Manual smoke test (if behavior changed)
+
+<!-- If this PR adds or modifies a `tools/*.py` file, re-run `./install.sh` before testing — hooks run against `~/.claude/tools/`, not the repo copy. -->

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,87 @@
+# Contributing to claude-engram
+
+Thanks for the interest. This is a small pre-launch project; contributions land fast when they follow the repo's conventions.
+
+## Setup
+
+Requires [Claude Code](https://docs.anthropic.com/en/docs/claude-code) and [`uv`](https://docs.astral.sh/uv/).
+
+```bash
+git clone https://github.com/sebastianbreguel/claude-engram.git
+cd claude-engram
+./install.sh        # copies tools to ~/.claude/, registers hooks
+```
+
+After editing anything under `tools/`, re-run `./install.sh` to redeploy to `~/.claude/`. Tests run against the repo copy; hooks run against the installed copy. The two will silently diverge if you skip the install step.
+
+## Running tests
+
+```bash
+uv run pytest -q
+```
+
+The full suite (~106 tests) should stay green on `main` and on every PR. CI runs the same command — `.github/workflows/test.yml`.
+
+If a single test is failing locally, narrow the run:
+
+```bash
+uv run pytest tests/test_engram_cli.py -k <name> -v
+```
+
+## Linting and formatting
+
+```bash
+uv run ruff check .
+uv run ruff format --check .
+```
+
+Both must pass before opening a PR. CI runs both. Settings live in `pyproject.toml` (`line-length = 140`, `quote-style = "double"`). Long lines are intentionally permitted in `tools/engram.py`, `tools/memcapture.py`, and `tests/test_e2e.py` for prompts, SQL, and formatted output — don't reformat them blindly.
+
+## Pre-commit (optional but recommended)
+
+```bash
+uv run pre-commit run --all-files
+```
+
+## Commit conventions
+
+Use conventional prefixes used elsewhere in the repo:
+
+- `feat:` — new user-visible capability
+- `fix:` — bug fix
+- `chore:` — repo housekeeping, deps, CI
+- `docs:` — documentation only
+- `refactor:` — internal restructure, no behavior change
+- `perf:` — measurable performance change
+- `cleanup:` — small dead-code or noise removal
+
+Keep messages short. The body, when present, should explain *why* the change was made — not what (the diff already shows that).
+
+## What we don't accept
+
+- **No `Co-Authored-By` lines** in commit messages.
+- **No "Generated with Claude Code" / "🤖 Generated with..." attribution lines** in commits, PR bodies, or any output.
+- **No `pip` / `python` / `python3` invocations** — `uv run` is the only Python entry point. The repo assumes `uv`-managed environments end-to-end.
+- **No `--no-verify` / `--no-gpg-sign`** to bypass hooks. If a hook fails, fix the cause.
+- **No new top-level dependencies without discussion.** The project ships with zero runtime dependencies (Python stdlib only) and treats this as a feature.
+
+## Pull requests
+
+PRs target `main`. The PR template (`.github/PULL_REQUEST_TEMPLATE.md`) pre-fills `## Summary` + `## Test plan` — keep both filled in.
+
+Smaller, focused PRs land faster than batched omnibus PRs. If a change touches multiple unrelated areas, split it.
+
+## Reporting bugs
+
+Open an issue with:
+
+- What you ran (`engram <subcommand>` invocation, or which hook fired)
+- What happened (stderr / log output)
+- What you expected
+- Output of `uv run ~/.claude/tools/engram.py verify-install` (catches repo↔install drift)
+
+## Further reading
+
+- [`docs/architecture.md`](docs/architecture.md) — how the hook + cache + DB pieces fit together
+- [`docs/cli-reference.md`](docs/cli-reference.md) — every subcommand
+- [`docs/privacy.md`](docs/privacy.md) — what's captured, what isn't, where it lives

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Claude-engram
 
+[![tests](https://img.shields.io/github/actions/workflow/status/sebastianbreguel/claude-engram/test.yml?branch=main&label=tests&style=flat)](https://github.com/sebastianbreguel/claude-engram/actions/workflows/test.yml) [![license](https://img.shields.io/github/license/sebastianbreguel/claude-engram?style=flat)](LICENSE)
+
 **Claude forgets everything between sessions.** Your preferences, your project state, where you left off — gone the moment you close the terminal.
 
 claude-engram fixes that. **~350 ambient tokens. No Docker, no API keys, no MCP.**


### PR DESCRIPTION
## Summary

- Adds `CONTRIBUTING.md` codifying the `uv`-only / `ruff` / `pytest -q` / no-Co-Authored-By rules from `CLAUDE.md` so external PRs don't trip implicit guardrails.
- Adds `.github/PULL_REQUEST_TEMPLATE.md` with minimal `## Summary` + `## Test plan` skeleton + an `install.sh` re-run footer for `tools/` edits.
- Adds CI-status + license badges to `README.md` under the H1 (shields.io, `flat` style).

Verifies issue #3 (executive cache atomic write) is already resolved by existing code at `tools/engram.py:715-742` and the three tests `test_executive_cache_rotates_to_prev` / `test_executive_cache_survives_tmp_write_failure` / `test_executive_cache_tmp_includes_pid`. Issue close comment drafted out-of-band; will close after merge.

Plugin marketplace schema doesn't yet document `screenshots[]` or `icon` fields, so `.claude-plugin/plugin.json` is unchanged. Deferred until the schema lands.

Plan: `docs/plans/2026-04-27-001-feat-pre-launch-readiness-sprint-plan.md` (untracked locally — not part of this PR's scope).

## Test plan

- [x] `uv run ruff check .` — clean
- [x] `uv run ruff format --check .` — 10 files already formatted
- [x] `uv run pytest -q` — 130 passed
- [x] `uv run pytest tests/test_engram_cli.py -k executive_cache -v` — 3 passed (issue #3 verification)
- [x] `python3 -c "import json; json.load(open('.claude-plugin/plugin.json'))"` — manifest still valid
- [ ] Visual: badges render in GitHub README after merge to `main` (CI badge needs `main` branch ref)