### PR TITLE
fix: resume correctness (placeholder stickiness + regex) + install/docs accuracy

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,14 +77,14 @@ Everything lives in `~/.claude/wherewasi/resume/<cwd-slug>.md` (plain Markdown).
 
 - **Stored**: project name, git branch + uncommitted count + last commit, and the two LLM-written `Last`/`Next` lines.
 - **NOT stored**: no full transcripts, no source code, no secrets from `.env`.
-- **LLM calls**: only on compaction, `claude --print` (default Sonnet 4.6 — override with `WWI_MODEL`, or set it empty for your account default) reads the **tail of the transcript** to write two lines. It runs under your existing Claude Code login — **no separate API key**. Set `WWI_SKIP_LLM=1` to disable it entirely (the resume still refreshes from git on the rolling path). Note: from **2026-06-15**, `claude -p` on subscription plans (Pro/Max/Team/Enterprise) draws from a monthly [Agent SDK credit](https://support.claude.com/en/articles/15036540-use-the-claude-agent-sdk-with-your-claude-plan) you claim once. If it runs out, the LLM rewrite pauses but the rolling git refresh and session-start display keep working.
+- **LLM calls**: on compaction (`PreCompact`) and at session end (`SessionEnd`), `claude --print` (default Sonnet 4.6 — override with `WWI_MODEL`, or set it empty for your account default) reads the **tail of the transcript** to write two lines. It runs under your existing Claude Code login — **no separate API key**. Set `WWI_SKIP_LLM=1` to disable it entirely (the resume still refreshes from git on the rolling path). Note: from **2026-06-15**, `claude -p` on subscription plans (Pro/Max/Team/Enterprise) draws from a monthly [Agent SDK credit](https://support.claude.com/en/articles/15036540-use-the-claude-agent-sdk-with-your-claude-plan) you claim once. If it runs out, the LLM rewrite pauses but the rolling git refresh and session-start display keep working.
 
 ## Environment variables
 
 | Variable | Default | Effect |
 |---|---|---|
 | `WWI_SHOW_BANNER` | `1` | Set to `0` to suppress the visible banner (context still injects) |
-| `WWI_SKIP_LLM` | unset | Set to `1` to skip the compaction LLM call (resume still refreshes from git) |
+| `WWI_SKIP_LLM` | unset | Set to `1` to skip the LLM rewrites (PreCompact + SessionEnd); resume still refreshes from git |
 | `WWI_MODEL` | `claude-sonnet-4-6` | Model for the LLM rewrite. Set empty to use your account default |
 | `WWI_DIGEST_EVERY` | `25` | Rolling-refresh cadence (prompts per `UserPromptSubmit` refresh) |
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,6 +1,6 @@
 # Architecture
 
-WhereWasI is a Claude Code plugin with **three hooks and one Python file**. No database, no daemon, no network I/O, no API keys. The entire plugin is `tools/wherewasi.py` (stdlib only).
+WhereWasI is a Claude Code plugin with **four hooks and one Python file**. No database, no daemon, no network I/O, no API keys. The entire plugin is `tools/wherewasi.py` (stdlib only).
 
 ## File layout (after install)
 
@@ -20,7 +20,7 @@ WhereWasI is a Claude Code plugin with **three hooks and one Python file**. No d
 
 ## Hook wiring
 
-Registered in `hooks/hooks.json` (plugin) / `~/.claude/settings.json` (manual install). Three events, one tool:
+Registered in `hooks/hooks.json` (plugin) / `~/.claude/settings.json` (manual install). Four events, one tool:
 
 ```json
 {
@@ -114,7 +114,8 @@ the two lines that actually carry intent.
 1. **One job, done well.** Show the last task + next step when you reopen a project. No
    search, no recall, no knowledge base.
 2. **Near-zero ambient cost.** ~120 tokens injected at SessionStart, read from a file. The
-   only LLM work is one `claude --print` call on compaction.
+   only LLM work is `claude --print`, on two paths: PreCompact (inline) and SessionEnd
+   (detached). Both are off the prompt hot path; set `WWI_SKIP_LLM=1` to disable them.
 3. **Files, not a database.** One Markdown file per project. No SQLite, no schema, no
    migrations, no FTS. Trivial to inspect (`cat`), trivial to reset (`rm`).
 4. **Best-effort, never blocks.** Every hook degrades silently: git failure → omit git
@@ -130,6 +131,6 @@ the two lines that actually carry intent.
 ## Why one file
 
 The whole surface is small: read git, read the transcript tail, render a Markdown block,
-wire three hooks. Collapsing it into a single `wherewasi.py` (vs. the multi-file
+wire four hooks. Collapsing it into a single `wherewasi.py` (vs. the multi-file
 `engram.py` + `memcapture.py` + `memdoctor.py` it replaced) means one place to read, one
 place to debug, and no import graph to hold in your head.

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -24,8 +24,10 @@ Slash command equivalents: `/wherewasi` (show) · `/wherewasi --reset` (clear).
 ```bash
 python3 ~/.claude/tools/wherewasi.py on-session-start   # SessionStart: render the resume
 python3 ~/.claude/tools/wherewasi.py on-user-prompt     # UserPromptSubmit: bump counter, rolling refresh
-python3 ~/.claude/tools/wherewasi.py on-precompact      # PreCompact: LLM rewrite of last task / next step
-python3 ~/.claude/tools/wherewasi.py capture-rolling --cwd PATH [--transcript FILE]   # the rolling refresh (spawned by on-user-prompt)
+python3 ~/.claude/tools/wherewasi.py on-precompact      # PreCompact: LLM rewrite of last task / next step (inline)
+python3 ~/.claude/tools/wherewasi.py on-session-end     # SessionEnd: LLM rewrite when you leave (detached)
+python3 ~/.claude/tools/wherewasi.py capture-rolling --cwd PATH [--transcript FILE]   # rolling refresh, no LLM (spawned by on-user-prompt)
+python3 ~/.claude/tools/wherewasi.py capture-llm --cwd PATH [--transcript FILE]       # LLM refresh (spawned by on-session-end)
 ```
 
 To test a hook by hand, pipe the payload to stdin:
@@ -40,7 +42,7 @@ echo '{"session_id":"abc","cwd":"'"$PWD"'"}' | \
 | Variable | Default | Effect |
 |---|---|---|
 | `WWI_SHOW_BANNER` | `1` | Set to `0` to suppress the visible banner (context still injects) |
-| `WWI_SKIP_LLM` | unset | Set to `1` to skip the compaction LLM call (resume still refreshes from git) |
+| `WWI_SKIP_LLM` | unset | Set to `1` to skip the LLM rewrites (PreCompact + SessionEnd); resume still refreshes from git |
 | `WWI_MODEL` | `claude-sonnet-4-6` | Model for the LLM rewrite. Set empty to use your account default |
 | `WWI_DIGEST_EVERY` | `25` | Rolling-refresh cadence (prompts per `UserPromptSubmit` refresh) |
 
@@ -50,8 +52,9 @@ echo '{"session_id":"abc","cwd":"'"$PWD"'"}' | \
 |---|---|---|
 | SessionStart inject | ~120 | Every session (the resume block) |
 | `on-user-prompt` rolling refresh | 0 | Every 25 prompts, no LLM |
-| `on-precompact` LLM rewrite | ~3-5K input | Only on compaction, one `claude --print` call |
-| **Ambient total** | **~120** | **Per session** |
+| `on-precompact` LLM rewrite | ~3-5K input | On compaction, one inline `claude --print` call |
+| `on-session-end` LLM rewrite | ~3-5K input | When a session ends, one detached `claude --print` call |
+| **Ambient total** | **~120** | **Per session** (LLM rewrites are off the prompt hot path; `WWI_SKIP_LLM=1` disables them) |
 
 ## Manual install
 
@@ -81,6 +84,11 @@ Then add these hooks to `~/.claude/settings.json`:
     "UserPromptSubmit": [
       {"matcher": "", "hooks": [
         {"type": "command", "command": "python3 $HOME/.claude/tools/wherewasi.py on-user-prompt"}
+      ]}
+    ],
+    "SessionEnd": [
+      {"matcher": "", "hooks": [
+        {"type": "command", "command": "python3 $HOME/.claude/tools/wherewasi.py on-session-end"}
       ]}
     ]
   }

--- a/docs/privacy.md
+++ b/docs/privacy.md
@@ -34,13 +34,13 @@ WhereWasI keeps one Markdown file per project at `~/.claude/wherewasi/resume/<sl
 WhereWasI makes **zero network requests** of its own. No telemetry, no analytics, no
 tracking.
 
-The only LLM interaction is `claude --print --model claude-sonnet-4-6`, invoked **on
-compaction only**. It reads the **tail of the current transcript** (last ~12 KB) and
-returns two lines (last task / next step). It runs locally through your own Claude Code
-session and uses whatever model and billing you already have configured — **no separate
-API key**. Set `WWI_SKIP_LLM=1` to disable it entirely; the resume still refreshes from git
-on the rolling path. Override the model with `WWI_MODEL` (set empty for your account
-default).
+The only LLM interaction is `claude --print --model claude-sonnet-4-6`, invoked on **two
+paths**: on compaction (`PreCompact`) and when a session ends (`SessionEnd`). Each reads the
+**tail of the current transcript** (last ~12 KB) and returns two lines (last task / next
+step). It runs locally through your own Claude Code session and uses whatever model and
+billing you already have configured — **no separate API key**. Set `WWI_SKIP_LLM=1` to
+disable both entirely; the resume still refreshes from git on the rolling path. Override the
+model with `WWI_MODEL` (set empty for your account default).
 
 ## Third-party services
 

--- a/install.sh
+++ b/install.sh
@@ -60,7 +60,9 @@ settings = json.loads(settings_path.read_text())
 hooks = settings.setdefault("hooks", {})
 
 # Markers for stale registrations to strip: this plugin (idempotent reinstall) + legacy engram.
-STALE = ("wherewasi.py", "engram.py", "memcapture", "memdigest", "memcompact", "mempatterns")
+# Anchor on concrete script filenames (commands look like `python3 .../tools/<name>.py …`) —
+# a bare "memcapture" would also strip an UNRELATED user hook whose command merely contains it.
+STALE = ("wherewasi.py", "engram.py", "memcapture.py", "mempatterns.py")
 
 
 def ensure_hook(event_name, command):
@@ -91,6 +93,7 @@ echo "What happens now:"
 echo "  - SessionStart: shows your last task + next step for this project (zero latency)"
 echo "  - Every 25 prompts: a cheap no-LLM refresh of the resume (git + edited files)"
 echo "  - On compaction: the LLM rewrites 'last task / next step' from the transcript"
+echo "  - On session end: the same LLM rewrite runs detached, so short sessions stay fresh"
 echo ""
 echo "Commands:"
 echo "  python3 ~/.claude/tools/wherewasi.py --cwd \"\$PWD\"          # print this project's resume"

--- a/tests/test_resume_doc.py
+++ b/tests/test_resume_doc.py
@@ -62,6 +62,62 @@ def test_write_creates_prev_backup(tmp_path):
     assert "v1" in (tmp_path / "proj.md.prev").read_text()
 
 
+def test_empty_fields_do_not_roundtrip_as_placeholder(tmp_path):
+    """Regression: render() used to write '(no task recorded)' to disk, load() read it back
+    as real data, so `prev_task or fallback` short-circuited forever and the resume stuck."""
+    p = tmp_path / "proj.md"
+    ResumeDoc(
+        project="proj",
+        task="",
+        next_step="",
+        git={"branch": "main", "uncommitted": 0, "commits": [], "dirty_files": []},
+    ).write(p)
+    disk = p.read_text()
+    assert "(no task recorded)" not in disk  # raw on disk, not the placeholder
+    assert "(no next step)" not in disk
+    loaded = ResumeDoc.load(p)
+    assert loaded.task == ""  # empty round-trips as empty
+    assert loaded.next_step == ""
+    # so the rolling/LLM-skip fallback chain actually reaches the transcript fallback
+    assert (loaded.task or "task from transcript") == "task from transcript"
+
+
+def test_load_neutralizes_legacy_placeholder_files(tmp_path):
+    """Files written by the old buggy render() still hold the placeholder on disk; load()
+    must treat it as empty so an already-stuck resume recovers on the next capture."""
+    p = tmp_path / "legacy.md"
+    p.write_text("# where was i: proj\n\nLast: (no task recorded)\nNext: (no next step)\n\nclean\n")
+    loaded = ResumeDoc.load(p)
+    assert loaded.task == ""
+    assert loaded.next_step == ""
+
+
+def test_load_does_not_grab_next_line_when_last_is_empty(tmp_path):
+    """Regression: the \\s*(.*) regex ate the newline and captured the Next: line as the task."""
+    p = tmp_path / "proj.md"
+    ResumeDoc(
+        project="proj",
+        task="",
+        next_step="ship it",
+        git={"branch": "main", "uncommitted": 0, "commits": [], "dirty_files": []},
+    ).write(p)
+    loaded = ResumeDoc.load(p)
+    assert loaded.task == ""  # not "Next: ship it"
+    assert loaded.next_step == "ship it"
+
+
+def test_render_placeholder_is_display_only(tmp_path):
+    """The friendly hint shows in the banner (placeholders=True) but never on disk."""
+    doc = ResumeDoc(
+        project="proj",
+        task="",
+        next_step="",
+        git={"branch": None, "uncommitted": 0, "commits": [], "dirty_files": []},
+    )
+    assert "(no task recorded)" in doc.render()  # display default
+    assert "(no task recorded)" not in doc.render(placeholders=False)  # disk
+
+
 def test_llm_skip_preserves_prior_narrative(monkeypatch, tmp_path):
     monkeypatch.setenv("HOME", str(tmp_path))
     monkeypatch.setenv("WWI_SKIP_LLM", "1")

--- a/tests/test_transcript_tail.py
+++ b/tests/test_transcript_tail.py
@@ -29,3 +29,16 @@ def test_extracts_latest_user_message_as_rough_task(tmp_path):
 
 def test_missing_file_returns_empty():
     assert parse_transcript_tail(Path("/nope/missing.jsonl")) == {"rough_task": ""}
+
+
+def test_multiline_message_collapses_to_one_line(tmp_path):
+    """A multi-line user message must collapse to a single line — a newline in rough_task
+    would write a multi-line Last:, and load()'s line-anchored regex would truncate it."""
+    t = tmp_path / "t.jsonl"
+    _write_jsonl(
+        t,
+        [{"type": "user", "message": {"role": "user", "content": "do step one\nthen step two\n  and three"}}],
+    )
+    out = parse_transcript_tail(t)
+    assert out == {"rough_task": "do step one then step two and three"}
+    assert "\n" not in out["rough_task"]

--- a/tools/wherewasi.py
+++ b/tools/wherewasi.py
@@ -56,8 +56,16 @@ def parse_transcript_tail(transcript_path: Path) -> dict:
             continue
         content = obj.get("message", {}).get("content")
         if obj.get("type") == "user" and isinstance(content, str) and content.strip():
-            rough_task = content.strip()[:200]  # latest wins
+            rough_task = " ".join(content.split())[:200]  # latest wins; collapse newlines → one line
     return {"rough_task": rough_task}
+
+
+# Display-only placeholders for an empty Last/Next. Shown in the banner / additionalContext,
+# NEVER written to disk: render(placeholders=False) serializes raw values so an empty resume
+# round-trips as empty instead of persisting this text as if it were a real task (which made
+# `prev_task or fallback` short-circuit forever — the resume stuck on "(no task recorded)").
+_NO_TASK = "(no task recorded)"
+_NO_NEXT = "(no next step)"
 
 
 class ResumeDoc:
@@ -71,21 +79,28 @@ class ResumeDoc:
         self.next_step = (next_step or "").strip()
         self.git = git or {}
 
-    def render(self) -> str:
+    def render(self, *, placeholders: bool = True) -> str:
         """Lean banner: the two narrative lines are the hero (Last = where you were,
         Next = what to do), with one compact git line for grounding. No file list, no
         last-error echo — the dev has `git` for that; padding it dilutes the two lines
-        that actually carry intent."""
+        that actually carry intent.
+
+        placeholders=True (display): show a friendly hint for an empty Last/Next.
+        placeholders=False (disk, via write()): serialize raw values so an empty field
+        round-trips as empty — writing the hint to disk made load() read it back as a
+        real task and the fallback chain never recovered."""
         g = self.git
         branch = g.get("branch")
         head = f"# where was i: {self.project}"
         if branch:
             head += f"  ·  branch {branch}"
+        last = self.task or (_NO_TASK if placeholders else "")
+        nxt = self.next_step or (_NO_NEXT if placeholders else "")
         lines = [
             head,
             "",
-            f"Last: {self.task or '(no task recorded)'}",
-            f"Next: {self.next_step or '(no next step)'}",
+            f"Last: {last}",
+            f"Next: {nxt}",
         ]
         if branch:
             commits = g.get("commits") or []
@@ -104,7 +119,7 @@ class ResumeDoc:
             except Exception:
                 pass
         tmp = path.with_suffix(path.suffix + ".tmp")
-        tmp.write_text(self.render())
+        tmp.write_text(self.render(placeholders=False))  # raw values on disk; hints are display-only
         tmp.replace(path)
 
     @classmethod
@@ -112,14 +127,25 @@ class ResumeDoc:
         text = Path(path).read_text()
 
         def _field(label: str) -> str:
-            m = re.search(rf"^{label}:\s*(.*)$", text, re.MULTILINE)
+            # Line-anchored on purpose: [ \t]* (not \s*, which eats the newline and would
+            # capture the *next* field when this one is empty) and [^\n]* (not .*, so the
+            # value can't bleed past its own line).
+            m = re.search(rf"^{label}:[ \t]*([^\n]*)$", text, re.MULTILINE)
             return m.group(1).strip() if m else ""
 
         proj = ""
         m = re.search(r"^# where was i:\s*([^·]+)", text, re.MULTILINE)
         if m:
             proj = m.group(1).strip()
-        return cls(project=proj, task=_field("Last"), next_step=_field("Next"), git={})
+        task, next_step = _field("Last"), _field("Next")
+        # Neutralize the display placeholders that pre-fix files wrote to disk, so an
+        # already-stuck "(no task recorded)" resume recovers instead of shadowing the fallback.
+        return cls(
+            project=proj,
+            task="" if task == _NO_TASK else task,
+            next_step="" if next_step == _NO_NEXT else next_step,
+            git={},
+        )
 
 
 def resume_path_for(cwd: str) -> Path:

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -42,7 +42,9 @@ if not settings_path.exists():
 settings = json.loads(settings_path.read_text())
 hooks = settings.get("hooks", {})
 
-MARKERS = ("wherewasi.py", "engram.py", "memcapture", "memdigest", "memcompact", "mempatterns")
+# Anchor on concrete script filenames so we never strip an unrelated user hook that merely
+# contains a substring like "memcapture". Keep this list identical to install.sh's STALE.
+MARKERS = ("wherewasi.py", "engram.py", "memcapture.py", "mempatterns.py")
 
 
 def strip(event_name):


### PR DESCRIPTION
Full-codebase review remediation — the HIGH-priority findings. Each was adversarially verified against the source; the top two were reproduced empirically.

## #1+#2 — resume no longer shows dead text (`cf340fa`)
`render()` wrote `(no task recorded)`/`(no next step)` to disk; `load()` read them back as real data, so `prev_task or tail` short-circuited forever and the resume stuck on the placeholder, never recovering the real task. The two bugs are **coupled** — fixing the placeholder alone (write an empty `Last:`) re-exposes a regex bug where `\s*(.*)` eats the newline and captures the `Next:` line as the task.

- `render(*, placeholders=)` — disk gets raw values; the hint is display-only (banner/additionalContext keep it)
- `_field()` regex line-anchored: `^{label}:[ \t]*([^\n]*)$`
- `load()` neutralizes legacy on-disk placeholders so already-stuck resumes recover
- `parse_transcript_tail` collapses newlines (multi-line message → single-line task)
- 5 regression tests (red against old code), end-to-end recovery confirmed through `capture_rolling`

## #3 — install no longer strips unrelated user hooks (`5fe85f4`)
Hook de-dup matched bare substrings like `memcapture`/`memdigest`, so a foreign user hook containing one of those tokens was silently removed from `settings.json`. Anchored on `.py` filenames; legacy engram hooks still caught via `engram.py`.

## #4 — docs/privacy accuracy (`bc7b540`)
Docs said "three hooks" and "LLM on compaction only", but SessionEnd is a 4th hook that also calls `claude --print` (PreCompact inline + SessionEnd detached). Accuracy fix for privacy.md/README (understated when the transcript tail is sent to the model), plus cli-reference and counter-path corrections.

**Gate:** 25/25 tests, ruff clean, both shell scripts + embedded Python parse.