### PR TITLE
feat: support Codex CLI alongside Claude Code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,25 @@
 # Changelog
 
+## Unreleased
+
+### Added
+- **Codex CLI support.** `install.sh` auto-detects `~/.codex` (or `$CODEX_HOME`) and wires
+  Codex too. Codex hooks share Claude Code's JSON stdin/stdout wire protocol, so the same
+  `tools/wherewasi.py` runs unchanged. Hooks wired: `SessionStart`, `UserPromptSubmit`,
+  `PreCompact`. Resume state is **shared** with Claude (`~/.claude/wherewasi/resume/<slug>.md`),
+  so switching harnesses on the same project shows the same resume. `uninstall.sh` removes the
+  Codex hooks symmetrically.
+
+### Notes
+- Codex has **no `SessionEnd`** event (and `Stop` fires every turn — too costly for the LLM
+  rewrite), so the end-of-session rewrite is skipped on Codex; `PreCompact` + the rolling git
+  refresh keep the resume fresh.
+- Codex injects the SessionStart resume into the **model** via `additionalContext` (no visible
+  banner — it renders neither `systemMessage` nor hook stderr). View it on demand with
+  `python3 ~/.codex/tools/wherewasi.py --cwd "$PWD"`.
+- Requires `[features].hooks = true` in `~/.codex/config.toml`; Codex may prompt to trust the
+  hook on first launch.
+
 ## 0.1.0 — WhereWasI (2026-05-28)
 
 **Breaking: renamed from `claude-engram` to `wherewasi` and pivoted from a generalized

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ This is **not** a memory bank. No search, no recall by topic, no accumulated his
 
 ## What you see
 
-When you open Claude Code in a project, WhereWasI injects a short resume at the top of the session:
+When you open Claude Code (or **Codex CLI**) in a project, WhereWasI injects a short resume at the top of the session:
 
 ```
 # where was i: wherewasi  ·  branch wherewasi-v2
@@ -36,7 +36,7 @@ Replace semantics: the file always reflects the current state. No history accumu
 
 ## Install
 
-**Requirements:** [Claude Code](https://docs.anthropic.com/en/docs/claude-code), `python3` (stdlib only — no `uv`, no pip, no deps).
+**Requirements:** [Claude Code](https://docs.anthropic.com/en/docs/claude-code) and/or [Codex CLI](https://developers.openai.com/codex), `python3` (stdlib only — no `uv`, no pip, no deps).
 
 **As a Claude Code plugin (recommended):**
 
@@ -53,6 +53,8 @@ cd wherewasi && ./install.sh
 ```
 
 > Use **the marketplace install OR `./install.sh`, not both** — each registers the hooks separately, so doing both fires every hook twice (and pays the compaction LLM cost twice).
+
+**Codex CLI (also supported):** `./install.sh` auto-detects `~/.codex` (or `$CODEX_HOME`) and wires Codex too. Codex hooks share Claude Code's JSON stdin/stdout wire protocol, so the same `wherewasi.py` runs unchanged. It needs `[features].hooks = true` in `~/.codex/config.toml`, and Codex may prompt to trust the hook on first launch. Resume state is **shared** with Claude (one `~/.claude/wherewasi/resume/<slug>.md` per project), so switching between the two on the same repo shows the same "where was I". Note: Codex has no `SessionEnd` event, so the end-of-session LLM rewrite is skipped there — `PreCompact` + the rolling git refresh keep it fresh.
 
 > **First session in a project:** you get a minimal git-only resume.
 > **After you've worked a bit:** the resume fills in with your last task + next step.

--- a/install.sh
+++ b/install.sh
@@ -86,6 +86,58 @@ ensure_hook("SessionEnd", "python3 $HOME/.claude/tools/wherewasi.py on-session-e
 settings_path.write_text(json.dumps(settings, indent=2) + "\n")
 PYEOF
 
+# ── Codex CLI (optional) ──────────────────────────────────────────────
+# Codex hooks share Claude Code's JSON stdin/stdout wire protocol, so the same
+# wherewasi.py runs unchanged. Config lives in $CODEX_HOME/hooks.json (not
+# settings.json) and is gated by `[features].hooks = true` in config.toml.
+# There is no SessionEnd event on Codex (Stop fires every turn — too costly for
+# the LLM rewrite), so it is skipped there; PreCompact + the rolling git refresh
+# keep the resume fresh. Resume state stays shared with Claude at ~/.claude/wherewasi/.
+CODEX_DIR="${CODEX_HOME:-$HOME/.codex}"
+if [ -d "$CODEX_DIR" ]; then
+    echo ""
+    echo "[codex] Detected $CODEX_DIR — wiring Codex too..."
+    mkdir -p "$CODEX_DIR/tools"
+    cp "$SCRIPT_DIR/tools/wherewasi.py" "$CODEX_DIR/tools/wherewasi.py"
+    chmod +x "$CODEX_DIR/tools/wherewasi.py"
+    echo "  -> $CODEX_DIR/tools/wherewasi.py"
+
+    python3 - "$CODEX_DIR" << 'PYEOF'
+import json, sys
+from pathlib import Path
+
+codex = Path(sys.argv[1])
+hp = codex / "hooks.json"
+data = json.loads(hp.read_text()) if hp.exists() else {}
+hooks = data.setdefault("hooks", {})
+
+# Codex renders neither the SessionStart `systemMessage` banner nor hook stderr — it only
+# consumes `additionalContext`, injected into the model (invisible in the TUI). So there is
+# no visible "where was I" banner on Codex; the resume reaches the model instead.
+WIRE = {
+    "SessionStart":     f"python3 {codex}/tools/wherewasi.py on-session-start",
+    "UserPromptSubmit": f"python3 {codex}/tools/wherewasi.py on-user-prompt",
+    "PreCompact":       f"python3 {codex}/tools/wherewasi.py on-precompact",
+}
+
+
+def ensure(event, command):
+    arr = hooks.setdefault(event, [])
+    for entry in arr:  # idempotent reinstall: drop any prior wherewasi entry, keep others (context-mode, etc.)
+        entry["hooks"] = [h for h in entry.get("hooks", []) if "wherewasi.py" not in h.get("command", "")]
+    arr[:] = [e for e in arr if e.get("hooks")]
+    arr.append({"hooks": [{"type": "command", "command": command}]})
+
+
+for ev, cmd in WIRE.items():
+    ensure(ev, cmd)
+
+hp.write_text(json.dumps(data, indent=2) + "\n")
+print(f"  Added Codex hooks: {', '.join(WIRE)}")
+PYEOF
+    echo "  Note: needs [features].hooks = true in config.toml; Codex may prompt to trust the hook on next launch."
+fi
+
 echo ""
 echo "Installation complete!"
 echo ""

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -63,4 +63,30 @@ settings_path.write_text(json.dumps(settings, indent=2) + "\n")
 print("  Hooks removed from settings.json")
 PYEOF
 
+# Codex CLI cleanup (no-op if Codex was never wired). Resume data under
+# ~/.claude/wherewasi was already removed above (shared state).
+CODEX_DIR="${CODEX_HOME:-$HOME/.codex}"
+if [ -d "$CODEX_DIR" ]; then
+    rm -f "$CODEX_DIR/tools/wherewasi.py"
+    if [ -f "$CODEX_DIR/hooks.json" ]; then
+        python3 - "$CODEX_DIR" << 'PYEOF'
+import json, sys
+from pathlib import Path
+
+hp = Path(sys.argv[1]) / "hooks.json"
+data = json.loads(hp.read_text())
+hooks = data.get("hooks", {})
+for ev in ("SessionStart", "UserPromptSubmit", "PreCompact"):
+    arr = hooks.get(ev, [])
+    for entry in arr:
+        entry["hooks"] = [h for h in entry.get("hooks", []) if "wherewasi.py" not in h.get("command", "")]
+    hooks[ev] = [e for e in arr if e.get("hooks")]
+    if not hooks[ev]:
+        del hooks[ev]
+hp.write_text(json.dumps(data, indent=2) + "\n")
+print("  Hooks removed from Codex hooks.json")
+PYEOF
+    fi
+fi
+
 echo "[3/3] Done."


### PR DESCRIPTION
## What

WhereWasI now works on **Codex CLI**, not just Claude Code.

Codex hooks share Claude Code's JSON stdin/stdout wire protocol, so the same `tools/wherewasi.py` runs unchanged — the work is config, not code.

## Changes

- **`install.sh`** — auto-detects `~/.codex` (or `$CODEX_HOME`), copies the script to `$CODEX_HOME/tools/`, and merges hooks into `~/.codex/hooks.json` (non-destructive; preserves other hooks like context-mode). Wires `SessionStart`, `UserPromptSubmit`, `PreCompact`. Idempotent.
- **`uninstall.sh`** — removes the Codex hooks + script symmetrically.
- **`README.md`** / **`CHANGELOG.md`** — document Codex support.

## Design notes

- **Shared resume state** with Claude (`~/.claude/wherewasi/resume/<slug>.md`) — switch harness on the same project, same resume.
- **No `SessionEnd` on Codex** (`Stop` fires every turn → too costly for the LLM rewrite), so the end-of-session rewrite is skipped there; `PreCompact` + the rolling git refresh keep it fresh.
- **No visible banner on Codex**: it injects the resume into the model via `additionalContext` (renders neither `systemMessage` nor hook stderr). View on demand: `python3 ~/.codex/tools/wherewasi.py --cwd "\$PWD"`.
- Requires `[features].hooks = true` in `~/.codex/config.toml`.

## Verification

- Hook contract tested: Codex-style payload via stdin → clean JSON on stdout with `additionalContext`.
- `install.sh` re-run confirmed idempotent (no duplicate hook entries).
- Live-wired on my setup; hooks confirmed executing in Codex.